### PR TITLE
Potential fix for code scanning alert no. 2: Failure to use secure cookies

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -807,7 +807,7 @@ def start_session(body: StartSessionRequest, request: Request, response: Respons
     if gs.id is not None:
         token = crud.sign_session_token(session, gs.id)
         # also set session_token cookie for convenience
-        response.set_cookie('session_token', token or '', httponly=True, samesite='lax')
+        response.set_cookie('session_token', token or '', httponly=True, samesite='lax', secure=True)
     return {"session_id": gs.id, "session_token": token, "start_ts": start_ts}
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/clxrityy/daily-set/security/code-scanning/2](https://github.com/clxrityy/daily-set/security/code-scanning/2)

To fix the problem, the `set_cookie` method should set the `secure=True` attribute for the session token cookie. This ensures the cookie will only be transmitted over HTTPS connections, significantly reducing the risk of interception. The best way to resolve the issue with minimal impact is to add `secure=True` to the parameters passed to `set_cookie` on line 810 in `app/main.py`. No new methods, imports, or changes elsewhere are needed; just adjust that single keyword argument in this invocation. This matches the already-secure pattern used in `_create_player_and_set_cookie`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
